### PR TITLE
[usermanager] Add access restrictions. Fixes JB#48598

### DIFF
--- a/org.sailfishos.usermanager.conf
+++ b/org.sailfishos.usermanager.conf
@@ -17,4 +17,10 @@ Peer"/>
     <allow send_destination="org.sailfishos.usermanager" send_interface="org.freedesktop.DBus.
 Properties"/>
   </policy>
+
+  <policy context="default">
+    <allow send_destination="org.sailfishos.usermanager" send_interface="org.sailfishos.usermanager" send_member="removeUser" />
+    <allow send_destination="org.sailfishos.usermanager" send_interface="org.sailfishos.usermanager" send_member="modifyUser" />
+    <allow send_destination="org.sailfishos.usermanager" send_interface="org.sailfishos.usermanager" send_member="users" />
+  </policy>
 </busconfig>

--- a/rpm/user-managerd.spec
+++ b/rpm/user-managerd.spec
@@ -8,6 +8,7 @@ URL: https://github.com/sailfishos/user-management-daemon.git
 BuildRequires: pkgconfig(Qt5Core)
 BuildRequires: pkgconfig(Qt5DBus)
 BuildRequires: pkgconfig(libuser)
+BuildRequires: pkgconfig(sailfishaccesscontrol) >= 0.0.3
 Requires: systemd
 Requires: sailfish-setup >= 0.1.12
 %description

--- a/sailfishusermanager.h
+++ b/sailfishusermanager.h
@@ -43,6 +43,8 @@ public slots:
     void modifyUser(uint uid, const QString &new_name);
 
 private:
+    bool hasAccessRights(uint uid_to_modify);
+
     QTimer *m_timer;
     LibUserHelper *m_lu;
 };

--- a/user-managerd.pro
+++ b/user-managerd.pro
@@ -15,7 +15,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-PKGCONFIG += libuser glib-2.0
+PKGCONFIG += libuser glib-2.0 sailfishaccesscontrol
 
 DBUS_SERVICE_NAME = org.sailfishos.usermanager
 dbus_interface.files = $${DBUS_SERVICE_NAME}.xml


### PR DESCRIPTION
Deny access to operations on users below uid 100000. Allow users not in
sailfish-system group to access the daemon but restrict their access to
only themselves. Prevent removal of device owner.