### PR TITLE
[usermanager] Save user for the next boot. Fixes JB#49459

### DIFF
--- a/sailfishusermanager.h
+++ b/sailfishusermanager.h
@@ -58,6 +58,7 @@ private slots:
 private:
     bool checkAccessRights(uint uid_to_modify);
     uid_t checkCallerUid();
+    void updateEnvironment(uint uid);
 
     QTimer *m_timer;
     LibUserHelper *m_lu;


### PR DESCRIPTION
Simple /etc/environment update so that the same user is used in the next boot too.