### PR TITLE
[user-managerd] Delay user switching. Contributes to JB#49640

### DIFF
--- a/sailfishusermanager.h
+++ b/sailfishusermanager.h
@@ -54,6 +54,7 @@ public slots:
     void removeFromGroups(uint uid, const QStringList &groups);
 
 private slots:
+    void exitTimeout();
     void userServiceStop(QDBusPendingCallWatcher *replyWatcher);
     void autologinServiceStop(QDBusPendingCallWatcher *replyWatcher);
     void autologinServiceStart(QDBusPendingCallWatcher *replyWatcher);


### PR DESCRIPTION
Delay user switching until UI transition has ended. Don't let exit timer
to activate if user switching is in progress so that if switching takes
a long time it still works as intended.