### PR TITLE
[user-mangerd] Add proper systemd job control. Fixes JB#49717

### DIFF
--- a/sailfishusermanager.h
+++ b/sailfishusermanager.h
@@ -11,7 +11,7 @@
 #define SAILFISHUSERMANAGER_H
 
 #include "sailfishusermanagerinterface.h"
-
+#include "systemdmanager.h"
 #include <QDBusContext>
 
 class QTimer;
@@ -55,9 +55,10 @@ public slots:
 
 private slots:
     void exitTimeout();
-    void userServiceStop(QDBusPendingCallWatcher *replyWatcher);
-    void autologinServiceStop(QDBusPendingCallWatcher *replyWatcher);
-    void autologinServiceStart(QDBusPendingCallWatcher *replyWatcher);
+    void onBusyChanged();
+    void onUnitJobFinished(SystemdManager::Job &job);
+    void onUnitJobFailed(SystemdManager::Job &job, SystemdManager::JobList &remaining);
+    void onCreatingJobFailed(SystemdManager::JobList &remaining);
 
 private:
     bool checkAccessRights(uint uid_to_modify);
@@ -68,7 +69,7 @@ private:
     LibUserHelper *m_lu;
     uid_t m_switchUser;
     uid_t m_currentUid;
-    QDBusInterface *m_systemd;
+    SystemdManager *m_systemd;
 };
 
 #endif // SAILFISHUSERMANAGER_H

--- a/systemdmanager.cpp
+++ b/systemdmanager.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2020 Open Mobile Platform LLC.
+ *
+ * All rights reserved.
+ *
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#include "systemdmanager.h"
+#include "logging.h"
+#include <QDBusInterface>
+#include <QDBusObjectPath>
+#include <QDBusPendingCall>
+#include <QDBusPendingReply>
+
+namespace Systemd {
+const auto Service = QStringLiteral("org.freedesktop.systemd1");
+const auto ManagerPath = QStringLiteral("/org/freedesktop/systemd1");
+const auto ManagerInterface = QStringLiteral("org.freedesktop.systemd1.Manager");
+const auto Replace = QStringLiteral("replace");
+const auto StartUnit = QStringLiteral("StartUnit");
+const auto StopUnit = QStringLiteral("StopUnit");
+const auto ResultDone = QStringLiteral("done");
+const auto ResultSkipped = QStringLiteral("skipped");
+}
+
+// This is currently implemented so that it can do one thing at a time
+// as there is no need for anything more complicated.
+// It would be quite easily possible to add individual queues with
+// queue numbers if needed.
+
+SystemdManager::SystemdManager(QObject *parent) :
+    QObject(parent),
+    m_systemd(new QDBusInterface(Systemd::Service, Systemd::ManagerPath,
+                                 Systemd::ManagerInterface,
+                                 QDBusConnection::systemBus(), this))
+{
+    if (!m_systemd->isValid())
+        qCCritical(lcSUM) << "Could not create interface to systemd, can not function!";
+    if (!connect(m_systemd, SIGNAL(JobRemoved(uint, QDBusObjectPath, QString, QString)),
+                 this, SLOT(onJobRemoved(uint, QDBusObjectPath, QString, QString))))
+        qCCritical(lcSUM) << "Could not connect to JobRemoved signal, can not function!";
+}
+
+SystemdManager::~SystemdManager()
+{
+    delete m_systemd;
+    m_systemd = nullptr;
+}
+
+bool SystemdManager::busy()
+{
+    // Busy if there is something on queue or a pending call or job removal is waited for
+    return !m_jobs.isEmpty() || m_pendingCall || !m_currentJob.isEmpty();
+}
+
+void SystemdManager::addUnitJob(Job job)
+{
+    addUnitJobs(JobList() << job);
+}
+
+void SystemdManager::addUnitJobs(JobList &jobs)
+{
+    Q_ASSERT_X(!jobs.isEmpty(), "addUnitJobs", "jobs must never be empty");
+    bool wasEmpty = m_jobs.isEmpty();
+    m_jobs.append(jobs);
+    processNextJob();
+    if (wasEmpty)
+        emit busyChanged();
+}
+
+void SystemdManager::processNextJob()
+{
+    if (m_pendingCall || !m_currentJob.isEmpty())
+        return;
+
+    qCDebug(lcSUM) << "Process next systemd job";
+
+    QDBusPendingCall call = m_systemd->asyncCall(
+            (m_jobs.first().type == StopJob) ? Systemd::StopUnit : Systemd::StartUnit,
+            m_jobs.first().unit, Systemd::Replace);
+    QDBusPendingCallWatcher *m_pendingCall = new QDBusPendingCallWatcher(call, this);
+    connect(m_pendingCall, &QDBusPendingCallWatcher::finished, this, &SystemdManager::pendingCallFinished);
+}
+
+void SystemdManager::pendingCallFinished(QDBusPendingCallWatcher *call)
+{
+    m_pendingCall = nullptr;
+    QDBusPendingReply<QDBusObjectPath> reply = *call;
+    if (reply.isError()) {
+        // This basically means that the job didn't do anything yet
+        qCWarning(lcSUM) << "Systemd job start failed" << reply.error();
+        JobList remaining;
+        remaining.swap(m_jobs);
+        emit creatingJobFailed(remaining);
+        if (!busy())
+            emit busyChanged();
+    } else {
+        m_currentJob = reply.value().path();
+        qCDebug(lcSUM) << "Current systemd job is now" << m_currentJob;
+    }
+    call->deleteLater();
+}
+
+void SystemdManager::onJobRemoved(uint id, QDBusObjectPath job, QString unit, QString result)
+{
+    Q_UNUSED(id)
+    if (job.path() == m_currentJob) {
+        qCWarning(lcSUM) << "Systemd job" << job.path() << "for unit" << unit
+                         << "ended with result" << result;
+        if (result == Systemd::ResultSkipped) {
+            // This means that the job didn't do anything yet
+            m_currentJob.clear(); // Clear busyness before signal
+            JobList remaining;
+            remaining.swap(m_jobs);
+            emit creatingJobFailed(remaining);
+        } else if (result != Systemd::ResultDone) {
+            // Uh, Houston, we've had a problem
+            m_currentJob.clear(); // Clear busyness before signal
+            Job failed = m_jobs.takeFirst();
+            JobList remaining;
+            remaining.swap(m_jobs);
+            emit unitJobFailed(failed, remaining);
+        } else {
+            Job done = m_jobs.takeFirst();
+            emit unitJobFinished(done);
+            m_currentJob.clear(); // Clear busyness *after* signal
+            if (!m_jobs.isEmpty())
+                processNextJob();
+        }
+        if (!busy()) // Check if we are busy still
+            emit busyChanged();
+    }
+}

--- a/systemdmanager.h
+++ b/systemdmanager.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 Open Mobile Platform LLC.
+ *
+ * All rights reserved.
+ *
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#ifndef SYSTEMDMANAGER_H
+#define SYSTEMDMANAGER_H
+
+#include <QObject>
+#include <QString>
+#include <QDBusObjectPath>
+
+class QDBusInterface;
+class QDBusPendingCallWatcher;
+
+class SystemdManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit SystemdManager(QObject *parent = nullptr);
+    ~SystemdManager();
+
+    enum JobType {
+        StartJob,
+        StopJob,
+    };
+    Q_ENUM(JobType);
+
+    // A job here means a systemd's job, which can be starting
+    // or stopping a systemd unit (usually a service), for instance
+    struct Job {
+        QString unit;
+        JobType type;
+
+        Job(QString unit, JobType type) : unit(unit), type(type) {}
+
+        static Job start(QString unit) { return Job(unit, StartJob); }
+        static Job stop(QString unit) { return Job(unit, StopJob); }
+    };
+
+    typedef QList<Job> JobList;
+
+    bool busy();
+    void addUnitJob(Job job);
+    void addUnitJobs(JobList &jobs);
+
+signals:
+    void busyChanged();
+    void unitJobFinished(Job &job);
+    void unitJobFailed(Job &job, JobList &remaining);
+    void creatingJobFailed(JobList &remaining);
+
+private slots:
+    void pendingCallFinished(QDBusPendingCallWatcher *call);
+    void onJobRemoved(uint id, QDBusObjectPath job, QString unit, QString result);
+
+private:
+    void processNextJob();
+
+    QDBusPendingCallWatcher *m_pendingCall;
+    JobList m_jobs;
+    QString m_currentJob;
+    QDBusInterface *m_systemd;
+};
+
+#endif // SYSTEMDMANAGER_H

--- a/user-managerd.pro
+++ b/user-managerd.pro
@@ -25,12 +25,14 @@ DBUS_ADAPTORS += dbus_interface
 
 SOURCES += \
         libuserhelper.cpp \
+        systemdmanager.cpp \
         logging.cpp \
         main.cpp \
         sailfishusermanager.cpp
 
 HEADERS += \
     libuserhelper.h \
+    systemdmanager.h \
     logging.h \
     sailfishusermanager.h \
     sailfishusermanagerinterface.h


### PR DESCRIPTION
This should clear up any issues with job management which improves user
switching a lot. It also somewhat robustifies error handling in case
some of the systemd units end with failure exit code.

Add SystemdManager class that is handles starting and stopping units. It
reports that job has finished only after the job has been removed. It
also improves code reuse as all units are handled with the same code.