### PR TITLE
Include types.h when not building with glibc

### DIFF
--- a/sailfishusermanager.h
+++ b/sailfishusermanager.h
@@ -10,6 +10,10 @@
 #ifndef SAILFISHUSERMANAGER_H
 #define SAILFISHUSERMANAGER_H
 
+#ifndef __GLIBC__
+#include <sys/types.h>
+#endif
+
 #include "sailfishusermanagerinterface.h"
 #include "systemdmanager.h"
 #include <QDBusContext>


### PR DESCRIPTION
Without it, `uid_t` is undefined on Musl.