### PR TITLE
[usermanager] Remove user environment files when user removed. Fixes …

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -14,6 +14,8 @@
 int main(int argc, char *argv[])
 {
     QCoreApplication app(argc, argv);
+    if (argc > 2 && !strcmp(argv[1], "--removeUserFiles"))
+        return SailfishUserManager::removeUserFiles(argv[2]);
     SailfishUserManager daemon;
     return app.exec();
 }

--- a/rpm/user-managerd.spec
+++ b/rpm/user-managerd.spec
@@ -14,6 +14,7 @@ BuildRequires: pkgconfig(mce-qt5)
 BuildRequires: sed
 Requires: systemd
 Requires: sailfish-setup >= 0.1.12
+Requires: shadow-utils
 %description
 %{summary}.
 
@@ -30,6 +31,7 @@ Requires: user-managerd
 %{_unitdir}/*.service
 %{_datadir}/dbus-1/system-services/*.service
 %{_sysconfdir}/dbus-1/system.d/*.conf
+%{_sbindir}/userdel_local.sh
 
 %files devel
 %{_prefix}/include/sailfishusermanager
@@ -53,3 +55,9 @@ systemctl stop dbus-org.sailfishos.usermanager.service || :
 
 %post
 systemctl daemon-reload
+sed -i 's/^\#USERDEL_CMD.*/USERDEL_CMD \/usr\/sbin\/userdel_local.sh/' /etc/login.defs
+
+%postun
+if [ $1 -eq 0 ]; then
+    sed -i 's/^USERDEL_CMD.*/\#USERDEL_CMD/' /etc/login.defs
+fi

--- a/sailfishusermanager.h
+++ b/sailfishusermanager.h
@@ -30,6 +30,7 @@ class SailfishUserManager : public QObject, protected QDBusContext
 public:
     explicit SailfishUserManager(QObject *parent = nullptr);
     ~SailfishUserManager();
+    static int removeUserFiles(const char *user);
 
 private:
     bool addUserToGroups(const QString &user);
@@ -37,6 +38,7 @@ private:
     bool removeDir(const QString &dir);
     bool removeHome(uint uid);
     bool copyDir(const QString &source, const QString &destination, uint uid, uint guid);
+    static int removeUserFiles(uint uid);
 
 signals:
     void userAdded(const SailfishUserManagerEntry &user);

--- a/user-managerd.pro
+++ b/user-managerd.pro
@@ -44,7 +44,8 @@ DISTFILES += \
     org.sailfishos.usermanager.conf \
     org.sailfishos.usermanager.service \
     org.sailfishos.usermanager.xml \
-    rpm/user-managerd.spec
+    rpm/user-managerd.spec \
+    userdel_local.sh
 
 target.path = /usr/bin/
 
@@ -63,4 +64,7 @@ pkgconfig.path = $$[QT_INSTALL_LIBS]/pkgconfig
 include.files = sailfishusermanagerinterface.h $${DBUS_SERVICE_NAME}.xml
 include.path = /usr/include/sailfishusermanager
 
-INSTALLS += target systemd service conf pkgconfig include
+userdel.files = userdel_local.sh
+userdel.path = /usr/sbin/
+
+INSTALLS += target systemd service conf pkgconfig include userdel

--- a/userdel_local.sh
+++ b/userdel_local.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/bin/user-managerd --removeUserFiles $1


### PR DESCRIPTION
Don't know if that shadow-utils userdel scripting is really that much needed but it's there now.