### PR TITLE
[user-managerd] Start user@.service explicitly. Fixes JB#49774

### DIFF
--- a/systemdmanager.cpp
+++ b/systemdmanager.cpp
@@ -18,6 +18,7 @@ const auto Service = QStringLiteral("org.freedesktop.systemd1");
 const auto ManagerPath = QStringLiteral("/org/freedesktop/systemd1");
 const auto ManagerInterface = QStringLiteral("org.freedesktop.systemd1.Manager");
 const auto Replace = QStringLiteral("replace");
+const auto Fail = QStringLiteral("fail");
 const auto StartUnit = QStringLiteral("StartUnit");
 const auto StopUnit = QStringLiteral("StopUnit");
 const auto ResultDone = QStringLiteral("done");
@@ -79,7 +80,7 @@ void SystemdManager::processNextJob()
 
     QDBusPendingCall call = m_systemd->asyncCall(
             (m_jobs.first().type == StopJob) ? Systemd::StopUnit : Systemd::StartUnit,
-            m_jobs.first().unit, Systemd::Replace);
+            m_jobs.first().unit, (m_jobs.first().replace) ? Systemd::Replace : Systemd::Fail);
     QDBusPendingCallWatcher *m_pendingCall = new QDBusPendingCallWatcher(call, this);
     connect(m_pendingCall, &QDBusPendingCallWatcher::finished, this, &SystemdManager::pendingCallFinished);
 }

--- a/systemdmanager.h
+++ b/systemdmanager.h
@@ -35,11 +35,12 @@ public:
     struct Job {
         QString unit;
         JobType type;
+        bool replace;
 
-        Job(QString unit, JobType type) : unit(unit), type(type) {}
+        Job(QString unit, JobType type, bool replace) : unit(unit), type(type), replace(replace) {}
 
-        static Job start(QString unit) { return Job(unit, StartJob); }
-        static Job stop(QString unit) { return Job(unit, StopJob); }
+        static Job start(QString unit, bool replace = true) { return Job(unit, StartJob, replace); }
+        static Job stop(QString unit, bool replace = true) { return Job(unit, StopJob, replace); }
     };
 
     typedef QList<Job> JobList;


### PR DESCRIPTION
Start user@.service explicitly when starting new session. Previously this relied on autologin@.service to start it through pam_systemd but in practice it may skip that if user-.slice is still active and thus user
session doesn't start properly. It shouldn't matter that pam_systemd is also starting user@.service because then systemd just reports the start job as 'done' and continues. Use 'fail' instead of 'replace' to not make changes to starting process if pam_systemd was faster.