### PR TITLE
[user-managerd] Add support for guest user. Fixes JB#50231

### DIFF
--- a/libuserhelper.h
+++ b/libuserhelper.h
@@ -16,7 +16,7 @@ class LibUserHelper
 {
 public:
     LibUserHelper();
-    uint addGroup(const QString &group);
+    uint addGroup(const QString &group, int gid = 0);
     bool removeGroup(const QString &group);
     bool addUserToGroup(const QString &user, const QString &group);
     bool removeUserFromGroup(const QString &user, const QString &group);

--- a/org.sailfishos.usermanager.xml
+++ b/org.sailfishos.usermanager.xml
@@ -58,6 +58,12 @@
         <arg direction="in" type="as" name="groups"/>
         <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QStringList"/>
     </method>
+    <method name="enableGuestUser">
+        <arg direction="in" type="b" name="enable"/>
+    </method>
+    <signal name="guestUserEnabled">
+        <arg type ="b" name="enabled"/>
+    </signal>
   </interface>
 </node>
 

--- a/rpm/user-managerd.spec
+++ b/rpm/user-managerd.spec
@@ -1,5 +1,5 @@
 Name: user-managerd
-Version: 0.0.1
+Version: 0.5.17
 Release: 1
 Summary: Sailfish user manager daemon
 License: BSD
@@ -28,7 +28,7 @@ Requires: user-managerd
 %files
 %defattr(-,root,root,-)
 %{_bindir}/%{name}
-%{_unitdir}/*.service
+%{_unitdir}/*
 %{_datadir}/dbus-1/system-services/*.service
 %{_sysconfdir}/dbus-1/system.d/*.conf
 %{_sbindir}/userdel_local.sh

--- a/sailfishusermanager.h
+++ b/sailfishusermanager.h
@@ -34,12 +34,13 @@ public:
 
 private:
     bool addUserToGroups(const QString &user);
-    bool makeHome(const QString &user);
+    bool makeHome(const QString &user, bool suwDone = false);
     bool removeDir(const QString &dir);
     bool removeHome(uint uid);
     bool copyDir(const QString &source, const QString &destination, uint uid, uint guid);
     static int removeUserFiles(uint uid);
     static void setUserLimits(uint uid);
+    uint addSailfishUser(const QString &user, const QString &name, uint userId = 0);
 
 signals:
     void userAdded(const SailfishUserManagerEntry &user);
@@ -48,6 +49,7 @@ signals:
     void currentUserChanged(uint uid);
     void currentUserChangeFailed(uint uid);
     void aboutToChangeCurrentUser(uint uid);
+    void guestUserEnabled(bool enabled);
 
 public slots:
     QList<SailfishUserManagerEntry> users();
@@ -59,6 +61,7 @@ public slots:
     QStringList usersGroups(uint uid);
     void addToGroups(uint uid, const QStringList &groups);
     void removeFromGroups(uint uid, const QStringList &groups);
+    void enableGuestUser(bool enable);
 
 private slots:
     void exitTimeout();
@@ -71,6 +74,7 @@ private:
     bool checkAccessRights(uint uid_to_modify);
     uid_t checkCallerUid();
     void updateEnvironment(uint uid);
+    void initSystemdManager();
 
     QTimer *m_exitTimer;
     LibUserHelper *m_lu;

--- a/sailfishusermanager.pc
+++ b/sailfishusermanager.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include/sailfishusermanager
 Name: sailfishusermanager
 Description: Sailfish user manager daemon development files
 URL: https://github.com/sailfishos/user-management-daemon/
-Version: 0.0.1
+Version: 0.5.16
 Requires: dbus-1
 Libs:
 Cflags: -I${includedir}

--- a/sailfishusermanagerinterface.h
+++ b/sailfishusermanagerinterface.h
@@ -15,6 +15,8 @@
 
 #define SAILFISH_USERMANAGER_DBUS_INTERFACE "org.sailfishos.usermanager"
 #define SAILFISH_USERMANAGER_DBUS_OBJECT_PATH "/"
+#define SAILFISH_USERMANAGER_GUEST_UID 111111
+#define SAILFISH_USERMANAGER_GUEST_HOME "/tmp/guest_home"
 
 // Luks has eight slots where one slot is reserved for backup
 #define SAILFISH_USERMANAGER_MAX_USERS 7

--- a/tmp-guest_home.mount
+++ b/tmp-guest_home.mount
@@ -1,0 +1,8 @@
+[Unit]
+After=tmp.mount
+
+[Mount]
+What=tmpfs
+Where=/tmp/guest_home
+Type=tmpfs
+Options=noauto,rw,size=1G,noexec

--- a/user-managerd.pro
+++ b/user-managerd.pro
@@ -45,12 +45,13 @@ DISTFILES += \
     org.sailfishos.usermanager.service \
     org.sailfishos.usermanager.xml \
     rpm/user-managerd.spec \
+    tmp-guest_home.mount \
     userdel_local.sh
 
 target.path = /usr/bin/
 
-systemd.files = dbus-$${DBUS_SERVICE_NAME}.service
-systemd.path = /usr/lib/systemd/system/
+systemd.files = dbus-$${DBUS_SERVICE_NAME}.service tmp-guest_home.mount
+systemd.path = $$[QT_INSTALL_LIBS]/systemd/system/
 
 service.files = $${DBUS_SERVICE_NAME}.service
 service.path = /usr/share/dbus-1/system-services/


### PR DESCRIPTION
So the idea in this one is if setCurrentUser 111111 is called then the guest user is created and switched to. Next setCurrentUser will delete the user. That uid is just something that I came up and open for debate, unlikely that a device will use more than 11K users :)