### PR TITLE
[user-managerd] Don't remove guest on logout. Fixes JB#50758 

### DIFF
--- a/guest_disable_suw.service
+++ b/guest_disable_suw.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Disable guest user startup wizard
+RequiresMountsFor=/tmp/guest_home
+PartOf=tmp-guest_home.mount
+After=create-home@105000.service
+Before=autologin@105000.service user@105000.service
+
+[Service]
+Type=oneshot
+User=sailfish-guest
+ExecStart=/bin/touch /tmp/guest_home/.jolla-startupwizard-done
+ExecStart=/bin/touch /tmp/guest_home/.jolla-startupwizard-usersession-done

--- a/libuserhelper.cpp
+++ b/libuserhelper.cpp
@@ -248,20 +248,24 @@ bool LibUserHelper::removeUser(uint uid)
             error = nullptr;
         }
 
-        if (rv && lu_group_lookup_id(context, lu_ent_get_first_id(ent, LU_GIDNUMBER), entGroup, &error)) {
-            if (lu_group_delete(context, entGroup, &error)) {
-                if (!lu_user_delete(context, ent, &error)) {
-                    qCWarning(lcSUM) << "User delete failed:" << lu_strerror(error);
-                    lu_error_free(&error);
-                    rv = false;
-                }
-            } else {
+        if (lu_group_lookup_id(context, lu_ent_get_first_id(ent, LU_GIDNUMBER), entGroup, &error)) {
+            if (!lu_group_delete(context, entGroup, &error)) {
                 qCWarning(lcSUM) << "Group delete failed:" << lu_strerror(error);
                 lu_error_free(&error);
+                error = nullptr;
                 rv = false;
             }
         } else {
             qCWarning(lcSUM) << "Could not find group";
+            if (error) {
+                lu_error_free(&error);
+                error = nullptr;
+            }
+            rv = false;
+        }
+
+        if (!lu_user_delete(context, ent, &error)) {
+            qCWarning(lcSUM) << "User delete failed:" << lu_strerror(error);
             lu_error_free(&error);
             rv = false;
         }

--- a/rpm/user-managerd.spec
+++ b/rpm/user-managerd.spec
@@ -28,7 +28,11 @@ Requires: user-managerd
 %files
 %defattr(-,root,root,-)
 %{_bindir}/%{name}
-%{_unitdir}/*
+%{_unitdir}/dbus-org.sailfishos.usermanager.service
+%{_unitdir}/tmp-guest_home.mount
+%{_unitdir}/*/tmp-guest_home.mount
+%{_unitdir}/guest_disable_suw.service
+%{_unitdir}/*/guest_disable_suw.service
 %{_datadir}/dbus-1/system-services/*.service
 %{_sysconfdir}/dbus-1/system.d/*.conf
 %{_sbindir}/userdel_local.sh
@@ -51,6 +55,11 @@ make %{?_smp_mflags}
 %install
 make -C build INSTALL_ROOT=%{buildroot} install
 mkdir -p %{buildroot}%{_datadir}/user-managerd/remove.d
+mkdir -p %{buildroot}%{_unitdir}/user@105000.service.wants/
+ln -s ../tmp-guest_home.mount %{buildroot}%{_unitdir}/user@105000.service.wants/
+mkdir -p %{buildroot}%{_unitdir}/autologin@105000.service.wants/
+ln -s ../tmp-guest_home.mount %{buildroot}%{_unitdir}/autologin@105000.service.wants/
+ln -s ../guest_disable_suw.service %{buildroot}%{_unitdir}/autologin@105000.service.wants/
 
 %pre
 systemctl stop dbus-org.sailfishos.usermanager.service || :

--- a/sailfishusermanager.cpp
+++ b/sailfishusermanager.cpp
@@ -305,26 +305,34 @@ uint SailfishUserManager::addSailfishUser(const QString &user, const QString &na
 {
     uint guid = m_lu->addGroup(user, userId);
     if (!guid) {
-        sendErrorReply(QStringLiteral(SailfishUserManagerErrorGroupCreateFailed), QStringLiteral("Creating user group failed"));
+        auto message = QStringLiteral("Creating user group failed");
+        qCWarning(lcSUM) << message;
+        sendErrorReply(QStringLiteral(SailfishUserManagerErrorGroupCreateFailed), message);
         return 0;
     }
 
     uint uid = m_lu->addUser(user, name, guid);
     if (!uid) {
         m_lu->removeGroup(user);
-        sendErrorReply(QStringLiteral(SailfishUserManagerErrorUserAddFailed), QStringLiteral("Adding user failed"));
+        auto message = QStringLiteral("Adding user failed");
+        qCWarning(lcSUM) << message;
+        sendErrorReply(QStringLiteral(SailfishUserManagerErrorUserAddFailed), message);
         return 0;
     }
 
     if (!addUserToGroups(user)) {
         m_lu->removeUser(uid);
-        sendErrorReply(QStringLiteral(SailfishUserManagerErrorUserModifyFailed), QStringLiteral("Adding user to groups failed"));
+        auto message = QStringLiteral("Adding user to groups failed");
+        qCWarning(lcSUM) << message;
+        sendErrorReply(QStringLiteral(SailfishUserManagerErrorUserModifyFailed), message);
         return 0;
     }
 
     if (!makeHome(user, userId == SAILFISH_USERMANAGER_GUEST_UID)) {
         m_lu->removeUser(uid);
-        sendErrorReply(QStringLiteral(SailfishUserManagerErrorHomeCreateFailed), QStringLiteral("Creating user home failed"));
+        auto message = QStringLiteral("Creating user home failed");
+        qCWarning(lcSUM) << message;
+        sendErrorReply(QStringLiteral(SailfishUserManagerErrorHomeCreateFailed), message);
         return 0;
     }
 
@@ -419,25 +427,31 @@ void SailfishUserManager::removeUser(uint uid)
         return;
 
     if (uid == OWNER_USER_UID) {
-        sendErrorReply(QDBusError::InvalidArgs, "Can not remove device owner");
+        auto message = QStringLiteral("Can not remove device owner");
+        qCWarning(lcSUM) << message;
+        sendErrorReply(QDBusError::InvalidArgs, message);
         return;
     }
 
     if (uid == currentUser()) {
-        sendErrorReply(QDBusError::InvalidArgs, "Can not remove current user");
+        auto message = QStringLiteral("Can not remove current user");
+        qCWarning(lcSUM) << message;
+        sendErrorReply(QDBusError::InvalidArgs, message);
         return;
     }
 
     m_exitTimer->start();
 
-    if (!removeHome(uid)) {
+    if (uid != SAILFISH_USERMANAGER_GUEST_UID && !removeHome(uid)) {
         qCWarning(lcSUM) << "Removing user home failed";
     }
 
     removeUserFiles(uid);
 
     if (!m_lu->removeUser(uid)) {
-        sendErrorReply(QStringLiteral(SailfishUserManagerErrorUserRemoveFailed), QStringLiteral("User remove failed"));
+        auto message = QStringLiteral("User remove failed");
+        qCWarning(lcSUM) << message;
+        sendErrorReply(QStringLiteral(SailfishUserManagerErrorUserRemoveFailed), message);
     } else {
         emit userRemoved(uid);
     }
@@ -451,7 +465,9 @@ void SailfishUserManager::modifyUser(uint uid, const QString &new_name)
     m_exitTimer->start();
 
     if (!m_lu->modifyUser(uid, new_name)) {
-        sendErrorReply(QStringLiteral(SailfishUserManagerErrorUserModifyFailed), QStringLiteral("User modify failed"));
+        auto message = QStringLiteral("User modify failed");
+        qCWarning(lcSUM) << message;
+        sendErrorReply(QStringLiteral(SailfishUserManagerErrorUserModifyFailed), message);
         return;
     }
 
@@ -853,7 +869,9 @@ void SailfishUserManager::enableGuestUser(bool enable)
         }
 
         if (currentUser() == SAILFISH_USERMANAGER_GUEST_UID) {
-            sendErrorReply(QDBusError::InvalidArgs, "Can not remove current user");
+            auto message = QStringLiteral("Can not remove current user");
+            qCWarning(lcSUM) << message;
+            sendErrorReply(QDBusError::InvalidArgs, message);
             return;
         }
 

--- a/sailfishusermanager.h
+++ b/sailfishusermanager.h
@@ -34,7 +34,7 @@ public:
 
 private:
     bool addUserToGroups(const QString &user);
-    bool makeHome(const QString &user, bool suwDone = false);
+    bool makeHome(const QString &user);
     bool removeDir(const QString &dir);
     bool removeHome(uint uid);
     bool copyDir(const QString &source, const QString &destination, uint uid, uint guid);

--- a/tmp-guest_home.mount
+++ b/tmp-guest_home.mount
@@ -1,8 +1,10 @@
 [Unit]
-After=tmp.mount
+Before=user@105000.service
+PartOf=user@105000.service
+Before=autologin@105000.service create-home@105000.service hw-groups@105000.service
 
 [Mount]
 What=tmpfs
 Where=/tmp/guest_home
 Type=tmpfs
-Options=noauto,rw,size=1G,noexec
+Options=noauto,rw,size=1G,noexec,uid=105000,gid=105000

--- a/user-managerd.pro
+++ b/user-managerd.pro
@@ -50,7 +50,7 @@ DISTFILES += \
 
 target.path = /usr/bin/
 
-systemd.files = dbus-$${DBUS_SERVICE_NAME}.service tmp-guest_home.mount
+systemd.files = dbus-$${DBUS_SERVICE_NAME}.service tmp-guest_home.mount guest_disable_suw.service
 systemd.path = /usr/lib/systemd/system/
 
 service.files = $${DBUS_SERVICE_NAME}.service


### PR DESCRIPTION
Don't remove guest user on logout so that it stays enabled. Also instead
of manually handling guest user data deletion and home directory
mounting or creation, leave that to systemd units. Add unit that handles
SUW files whenever guest user logs in.

Log all error messages to journal. Previously some were just signaled 
over D-Bus but not logged. Much easier to debug now.

Remove user even if some group removal fails. Otherwise this could
result in some odd situations that user just can't be removed from UI.