### PR TITLE
[user-managerd] Don't count guest user to limit. Contributes to JB#50772

### DIFF
--- a/sailfishusermanager.cpp
+++ b/sailfishusermanager.cpp
@@ -237,7 +237,9 @@ uint SailfishUserManager::addUser(const QString &name)
     struct group *grent = getgrnam(USER_GROUP);
     if (grent) {
         for (int i = 0; grent->gr_mem[i]; i++) {
-            if (getpwnam(grent->gr_mem[i]))
+            // Guest user is not counted to number of users that can be created
+            struct passwd *pw = getpwnam(grent->gr_mem[i]);
+            if (pw && (pw->pw_uid != SAILFISH_USERMANAGER_GUEST_UID))
                 count++;
         }
     }


### PR DESCRIPTION
Guest user should not be counted to maximum number of users that can be
created since it doesn't occupy LUKS slot and is outside typical UID
range.

See also [nemo-qml-plugin-systemsettings!151](https://git.sailfishos.org/mer-core/nemo-qml-plugin-systemsettings/merge_requests/151)