### PR TITLE
Move guest's home to /home

### DIFF
--- a/guest_disable_suw.service
+++ b/guest_disable_suw.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Disable guest user startup wizard
-RequiresMountsFor=/tmp/guest_home
-PartOf=tmp-guest_home.mount
+RequiresMountsFor=/home/sailfish_guest
+PartOf=home-sailfish_guest.mount
 After=create-home@105000.service
 Before=autologin@105000.service user@105000.service
 
 [Service]
 Type=oneshot
 User=sailfish-guest
-ExecStart=/bin/touch /tmp/guest_home/.jolla-startupwizard-done
-ExecStart=/bin/touch /tmp/guest_home/.jolla-startupwizard-usersession-done
+ExecStart=/bin/touch /home/sailfish_guest/.jolla-startupwizard-done
+ExecStart=/bin/touch /home/sailfish_guest/.jolla-startupwizard-usersession-done

--- a/home-sailfish_guest.mount
+++ b/home-sailfish_guest.mount
@@ -5,6 +5,6 @@ Before=autologin@105000.service create-home@105000.service hw-groups@105000.serv
 
 [Mount]
 What=tmpfs
-Where=/tmp/guest_home
+Where=/home/sailfish_guest
 Type=tmpfs
 Options=noauto,rw,size=1G,noexec,uid=105000,gid=105000

--- a/libuserhelper.h
+++ b/libuserhelper.h
@@ -20,7 +20,7 @@ public:
     bool removeGroup(const QString &group);
     bool addUserToGroup(const QString &user, const QString &group);
     bool removeUserFromGroup(const QString &user, const QString &group);
-    uint addUser(const QString &user, const QString &name, uint guid);
+    uint addUser(const QString &user, const QString &name, uint uid = 0, const QString &home = QString());
     bool removeUser(uint uid);
     bool modifyUser(uint uid, const QString &newName);
     QString homeDir(uint uid);

--- a/rpm/user-managerd.spec
+++ b/rpm/user-managerd.spec
@@ -29,8 +29,8 @@ Requires: user-managerd
 %defattr(-,root,root,-)
 %{_bindir}/%{name}
 %{_unitdir}/dbus-org.sailfishos.usermanager.service
-%{_unitdir}/tmp-guest_home.mount
-%{_unitdir}/*/tmp-guest_home.mount
+%{_unitdir}/home-sailfish_guest.mount
+%{_unitdir}/*/home-sailfish_guest.mount
 %{_unitdir}/guest_disable_suw.service
 %{_unitdir}/*/guest_disable_suw.service
 %{_datadir}/dbus-1/system-services/*.service
@@ -56,9 +56,9 @@ make %{?_smp_mflags}
 make -C build INSTALL_ROOT=%{buildroot} install
 mkdir -p %{buildroot}%{_datadir}/user-managerd/remove.d
 mkdir -p %{buildroot}%{_unitdir}/user@105000.service.wants/
-ln -s ../tmp-guest_home.mount %{buildroot}%{_unitdir}/user@105000.service.wants/
+ln -s ../home-sailfish_guest.mount %{buildroot}%{_unitdir}/user@105000.service.wants/
 mkdir -p %{buildroot}%{_unitdir}/autologin@105000.service.wants/
-ln -s ../tmp-guest_home.mount %{buildroot}%{_unitdir}/autologin@105000.service.wants/
+ln -s ../home-sailfish_guest.mount %{buildroot}%{_unitdir}/autologin@105000.service.wants/
 ln -s ../guest_disable_suw.service %{buildroot}%{_unitdir}/autologin@105000.service.wants/
 
 %pre

--- a/sailfishusermanager.cpp
+++ b/sailfishusermanager.cpp
@@ -278,17 +278,9 @@ uint SailfishUserManager::addUser(const QString &name)
     return addSailfishUser(user, name);
 }
 
-uint SailfishUserManager::addSailfishUser(const QString &user, const QString &name, uint userId)
+uint SailfishUserManager::addSailfishUser(const QString &user, const QString &name, uint userId, const QString &home)
 {
-    uint guid = m_lu->addGroup(user, userId);
-    if (!guid) {
-        auto message = QStringLiteral("Creating user group failed");
-        qCWarning(lcSUM) << message;
-        sendErrorReply(QStringLiteral(SailfishUserManagerErrorGroupCreateFailed), message);
-        return 0;
-    }
-
-    uint uid = m_lu->addUser(user, name, guid);
+    uint uid = m_lu->addUser(user, name, userId, home);
     if (!uid) {
         m_lu->removeGroup(user);
         auto message = QStringLiteral("Adding user failed");
@@ -827,7 +819,7 @@ void SailfishUserManager::enableGuestUser(bool enable)
 
     if (enable != (bool)getpwuid(SAILFISH_USERMANAGER_GUEST_UID)) {
         if (enable) {
-            if (addSailfishUser(GUEST_USER, "", SAILFISH_USERMANAGER_GUEST_UID))
+            if (addSailfishUser(GUEST_USER, "", SAILFISH_USERMANAGER_GUEST_UID, SAILFISH_USERMANAGER_GUEST_HOME))
                 emit guestUserEnabled(true);
         } else {
             removeUser(SAILFISH_USERMANAGER_GUEST_UID);

--- a/sailfishusermanager.h
+++ b/sailfishusermanager.h
@@ -40,7 +40,7 @@ private:
     bool copyDir(const QString &source, const QString &destination, uint uid, uint guid);
     static int removeUserFiles(uint uid);
     static void setUserLimits(uint uid);
-    uint addSailfishUser(const QString &user, const QString &name, uint userId = 0);
+    uint addSailfishUser(const QString &user, const QString &name, uint userId = 0, const QString &home = QString());
 
 signals:
     void userAdded(const SailfishUserManagerEntry &user);

--- a/sailfishusermanagerinterface.h
+++ b/sailfishusermanagerinterface.h
@@ -16,7 +16,7 @@
 #define SAILFISH_USERMANAGER_DBUS_INTERFACE "org.sailfishos.usermanager"
 #define SAILFISH_USERMANAGER_DBUS_OBJECT_PATH "/"
 #define SAILFISH_USERMANAGER_GUEST_UID 105000
-#define SAILFISH_USERMANAGER_GUEST_HOME "/tmp/guest_home"
+#define SAILFISH_USERMANAGER_GUEST_HOME "/home/sailfish_guest"
 
 // Luks has eight slots where one slot is reserved for backup
 #define SAILFISH_USERMANAGER_MAX_USERS 7

--- a/user-managerd.pro
+++ b/user-managerd.pro
@@ -45,12 +45,12 @@ DISTFILES += \
     org.sailfishos.usermanager.service \
     org.sailfishos.usermanager.xml \
     rpm/user-managerd.spec \
-    tmp-guest_home.mount \
+    home-sailfish_guest.mount \
     userdel_local.sh
 
 target.path = /usr/bin/
 
-systemd.files = dbus-$${DBUS_SERVICE_NAME}.service tmp-guest_home.mount guest_disable_suw.service
+systemd.files = dbus-$${DBUS_SERVICE_NAME}.service home-sailfish_guest.mount guest_disable_suw.service
 systemd.path = /usr/lib/systemd/system/
 
 service.files = $${DBUS_SERVICE_NAME}.service


### PR DESCRIPTION
There isn't any real reason to keep guest's home in /tmp since it lives in a separate file system. Mount it under /home that for example tracker works correctly. Note that the home directory is still different from the /home/$USER scheme as it uses an underscore instead of a dash.

Also I'm refactoring the code a bit. Move group creation inside LibUserHelper::addUser and remove any references to guest user. Instead allow setting uid and home directory path explicitly. This keeps the duties of SailfishUserManager and LibUserHelper a bit cleaner.