### PR TITLE
[user-managerd] Update to use group_ids.env. JB#51329

### DIFF
--- a/rpm/user-managerd.spec
+++ b/rpm/user-managerd.spec
@@ -14,7 +14,7 @@ BuildRequires: pkgconfig(mce-qt5)
 BuildRequires: sed
 BuildRequires: mer-qdoc-template
 Requires: systemd
-Requires: sailfish-setup >= 0.1.12
+Requires: sailfish-setup >= 0.3.0
 Requires: shadow-utils
 %description
 %{summary}.

--- a/src/sailfishusermanager.cpp
+++ b/src/sailfishusermanager.cpp
@@ -562,7 +562,7 @@ uid_t SailfishUserManager::checkCallerUid()
         return uid;
     }
 
-    if (info.group() != QStringLiteral("privileged")) {
+    if (info.group() != QStringLiteral("privileged") && !sailfish_access_control_hasgroup(uid, "privileged")) {
         // Non-privileged applications are not allowed
         auto message = QStringLiteral("PID %1 is not in privileged group").arg(pid);
         qCWarning(lcSUM) << "Access denied:" << message;


### PR DESCRIPTION
File format for specifying groups for users changed in sailfish-setup,
this changes user-managerd to support that. Also add users to the rest
of the groups even in case of an error and also slightly better error
reporting in that case.

Also change privileged check to check also that if user belongs to
privileged group, they should be allowed. This is for sailfish-mdm user.

Requires: https://github.com/sailfishos/sailfish-setup/pull/20