### PR TITLE
Fixes to group management

### DIFF
--- a/src/libuserhelper.cpp
+++ b/src/libuserhelper.cpp
@@ -54,7 +54,7 @@ uint LibUserHelper::addGroup(const QString &group, int gid)
     return rv;
 }
 
-bool LibUserHelper::removeGroup(const QString &group)
+bool LibUserHelper::removeGroup(uint gid)
 {
     struct lu_error *error = nullptr;
     struct lu_context *context = lu_start(NULL, lu_user, NULL, NULL, NULL, NULL, &error);
@@ -67,7 +67,7 @@ bool LibUserHelper::removeGroup(const QString &group)
 
     bool rv = true;
     struct lu_ent *ent_group = lu_ent_new();
-    if (lu_group_lookup_name(context, group.toUtf8(), ent_group, &error)) {
+    if (lu_group_lookup_id(context, gid, ent_group, &error)) {
         if (!lu_group_delete(context, ent_group, &error)) {
             qCWarning(lcSUM) << "Group delete failed";
             lu_error_free(&error);
@@ -207,6 +207,8 @@ uint LibUserHelper::addUser(const QString &user, const QString& name, uint uid, 
             if (gid != rv)
                 qCWarning(lcSUM) << "Group id" << gid << "is not the same as user id" << rv;
         } else {
+            // Clean up after failed user add attempt
+            removeGroup(gid);
             qCWarning(lcSUM) << "Adding user failed:" << lu_strerror(error);
             lu_error_free(&error);
         }

--- a/src/libuserhelper.h
+++ b/src/libuserhelper.h
@@ -17,7 +17,7 @@ class LibUserHelper
 public:
     LibUserHelper();
     uint addGroup(const QString &group, int gid = 0);
-    bool removeGroup(const QString &group);
+    bool removeGroup(uint gid);
     bool addUserToGroup(const QString &user, const QString &group);
     bool removeUserFromGroup(const QString &user, const QString &group);
     uint addUser(const QString &user, const QString &name, uint uid = 0, const QString &home = QString());

--- a/src/sailfishusermanager.cpp
+++ b/src/sailfishusermanager.cpp
@@ -324,14 +324,9 @@ uint SailfishUserManager::addUser(const QString &name)
     i = 0;
     QString user(cleanName);
     // Append number until it's unused
-    while (getpwnam(user.toUtf8()))
+    while (getpwnam(user.toUtf8()) || getgrnam(user.toUtf8())
+            || QFile::exists(QString(USER_HOME).arg(user))) {
         user = cleanName + QString::number(i++);
-
-    if (QFile::exists(QString(USER_HOME).arg(user))) {
-        auto message = QStringLiteral("Home directory already exists");
-        qCWarning(lcSUM) << message;
-        sendErrorReply(QStringLiteral(SailfishUserManagerErrorHomeCreateFailed), message);
-        return 0;
     }
 
     return addSailfishUser(user, name);
@@ -341,7 +336,6 @@ uint SailfishUserManager::addSailfishUser(const QString &user, const QString &na
 {
     uint uid = m_lu->addUser(user, name, userId, home);
     if (!uid) {
-        m_lu->removeGroup(user);
         auto message = QStringLiteral("Adding user failed");
         qCWarning(lcSUM) << message;
         sendErrorReply(QStringLiteral(SailfishUserManagerErrorUserAddFailed), message);

--- a/src/sailfishusermanager.h
+++ b/src/sailfishusermanager.h
@@ -75,6 +75,7 @@ private slots:
 private:
     bool checkAccessRights(uint uid_to_modify);
     uid_t checkCallerUid();
+    bool checkIsPermissionGroup(const QStringList &groups);
     void updateEnvironment(uint uid);
     void initSystemdManager();
 


### PR DESCRIPTION
Check that groups added with addToGroups or removed with
removeFromGroups are prefixed with sailfish- or account- prefix.

Change removeGroup to take gid instead of group name and move group
removal on failure inside LibUserHelper::addUser() as it knows better
how to deal with it.

Check in SailfishUserManager::addUser() that the group name is not
reserved. Also treat already existing home directory the same way
(increment the number at the end of username).