### PR TITLE
[usermanager] Add support for user creation scripts and move remove scripts to functions. Contributes to JB#53668

### DIFF
--- a/rpm/user-managerd.spec
+++ b/rpm/user-managerd.spec
@@ -44,6 +44,7 @@ Summary: Sailfish User Manager Daemon documentation
 %{_sysconfdir}/dbus-1/system.d/*.conf
 %{_sbindir}/userdel_local.sh
 %{_datadir}/user-managerd/remove.d
+%{_datadir}/user-managerd/create.d
 
 %files devel
 %{_prefix}/include/sailfishusermanager
@@ -63,6 +64,7 @@ make %{?_smp_mflags}
 %qmake5_install
 
 mkdir -p %{buildroot}%{_datadir}/user-managerd/remove.d
+mkdir -p %{buildroot}%{_datadir}/user-managerd/create.d
 mkdir -p %{buildroot}%{_unitdir}/user@105000.service.wants/
 ln -s ../home-sailfish_guest.mount %{buildroot}%{_unitdir}/user@105000.service.wants/
 mkdir -p %{buildroot}%{_unitdir}/autologin@105000.service.wants/

--- a/src/sailfishusermanager.h
+++ b/src/sailfishusermanager.h
@@ -38,6 +38,7 @@ private:
     bool removeDir(const QString &dir);
     bool removeHome(uint uid);
     bool copyDir(const QString &source, const QString &destination, uint uid, uint guid);
+    static void executeScripts(uint uid, const QString &directory);
     static int removeUserFiles(uint uid);
     static void setUserLimits(uint uid);
     uint addSailfishUser(const QString &user, const QString &name, uint userId = 0, const QString &home = QString());


### PR DESCRIPTION
Add support for user creation scripts with root rights when new user is creating.
Newuser oneshot are working only with new user rights, that not enough to create system folders.

adding sorting of file for remove scripts 