### PR TITLE
[user-managerd] Add script execution on user pre-switch. JB#55415

### DIFF
--- a/rpm/user-managerd.spec
+++ b/rpm/user-managerd.spec
@@ -45,6 +45,7 @@ Summary: Sailfish User Manager Daemon documentation
 %{_sbindir}/userdel_local.sh
 %{_datadir}/user-managerd/remove.d
 %{_datadir}/user-managerd/create.d
+%{_datadir}/user-managerd/pre-switch.d
 
 %files devel
 %{_prefix}/include/sailfishusermanager
@@ -65,6 +66,7 @@ make %{?_smp_mflags}
 
 mkdir -p %{buildroot}%{_datadir}/user-managerd/remove.d
 mkdir -p %{buildroot}%{_datadir}/user-managerd/create.d
+mkdir -p %{buildroot}%{_datadir}/user-managerd/pre-switch.d
 mkdir -p %{buildroot}%{_unitdir}/user@105000.service.wants/
 ln -s ../home-sailfish_guest.mount %{buildroot}%{_unitdir}/user@105000.service.wants/
 mkdir -p %{buildroot}%{_unitdir}/autologin@105000.service.wants/

--- a/src/sailfishusermanager.cpp
+++ b/src/sailfishusermanager.cpp
@@ -57,6 +57,7 @@ const int MAX_USERNAME_LENGTH = 20;
 const auto USER_ENVIRONMENT_DIR = QStringLiteral("/home/.system/var/lib/environment/%1");
 const auto USER_REMOVE_SCRIPT_DIR = QStringLiteral("/usr/share/user-managerd/remove.d");
 const auto USER_CREATE_SCRIPT_DIR = QStringLiteral("/usr/share/user-managerd/create.d");
+const auto USER_PRE_SWITCH_SCRIPT_DIR = QStringLiteral("/usr/share/user-managerd/pre-switch.d");
 const quint64 MAXIMUM_QUOTA_LIMIT = 2000000000ULL;
 const auto SAILFISH_GROUP_PREFIX = QStringLiteral("sailfish-");
 const auto ACCOUNT_GROUP_PREFIX = QStringLiteral("account-");
@@ -701,6 +702,9 @@ void SailfishUserManager::setCurrentUser(uint uid)
         if (!m_systemd) {
             initSystemdManager();
         }
+
+        executeScripts(m_currentUid, USER_PRE_SWITCH_SCRIPT_DIR);
+
         qCDebug(lcSUM) << "Switching user from" << m_currentUid << "to" << m_switchUser << "now";
         m_systemd->addUnitJobs(SystemdManager::JobList()
                                << SystemdManager::Job::stop(USER_SERVICE.arg(m_currentUid))


### PR DESCRIPTION
Added ~~new two points of the~~ script execution:
* `user pre switch` is called before switching to the another user.
* ~~`user session` on the new user session: user boot up or after switch to the another user. That point was added via new command line arg `--session` because user-managerd does not catch that state.~~
